### PR TITLE
Change the create event page

### DIFF
--- a/BlazorTicketCode/Pages/CreateEvent.razor
+++ b/BlazorTicketCode/Pages/CreateEvent.razor
@@ -2,39 +2,38 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Web
 @page "/create"
+@page "/create/{EventId:int?}"
 @inject HttpClient Http
 @inject NavigationManager Navigation
 
 <div class="create-container">
-    <h1>Create an event</h1>
+    <h1>Create/Update event</h1>
 
     <div class="form-container">
 
-<EditForm Model="@eventModel" OnValidSubmit="SubmitEvent">
-    <DataAnnotationsValidator />
-    <ValidationSummary />
+        <EditForm Model="@eventModel" OnValidSubmit="SubmitEvent">
+            <DataAnnotationsValidator />
+            <ValidationSummary />
 
-    <div class="mb-3">
-        <label for="Name" class="form-label">Name:</label>
-        <InputText id="Name" @bind-Value="@eventModel.Name" class="form-control" required></InputText>
-    </div>
+            <div class="mb-3">
+                <label for="Name" class="form-label">Name:</label>
+                <InputText id="Name" @bind-Value="@eventModel.Name" class="form-control" required></InputText>
+            </div>
 
-    <div class="mb-3">
-        <label for="Description" class="form-label">Description:</label>
-        <InputText id="Description" @bind-Value="@eventModel.Description" class="form-control" required></InputText>
-    </div>
+            <div class="mb-3">
+                <label for="Description" class="form-label">Description:</label>
+                <InputText id="Description" @bind-Value="@eventModel.Description" class="form-control" required></InputText>
+            </div>
 
-    <div class="mb-3">
-        <label for="Type" class="form-label">Type of event:</label>
+            <div class="mb-3">
+                <label for="Type" class="form-label">Type of event:</label>
                 <InputSelect id="Type" @bind-Value="@eventModel.Type" class="form-select" required>
                     @foreach (var type in Enum.GetValues<EventType>())
                     {
                         <option value="@type">@type</option>
                     }
                 </InputSelect>
-
-                
-    </div>
+            </div>
 
             <div class="mb-3">
                 <label for="StartTime" class="form-label">Start time:</label>
@@ -45,54 +44,113 @@
                 <label for="EndTime" class="form-label">End time:</label>
                 <InputText id="EndTime" @bind-Value="@endTimeString" type="datetime-local" class="form-control" required />
             </div>
- 
-    <div class="mb-3">
-        <label for="MaxAttendees" class="form-label">Max attendees:</label>
-        <InputNumber id="MaxAttendees" @bind-Value="@eventModel.MaxAttendees" class="form-control" required></InputNumber>
-    </div>
 
-    <button type="submit" class="btn btn-primary" disabled="@isLoading">
-        @(isLoading ? "Creating..." : "Create Event")
-    </button>
+            <div class="mb-3">
+                <label for="MaxAttendees" class="form-label">Max attendees:</label>
+                <InputNumber id="MaxAttendees" @bind-Value="@eventModel.MaxAttendees" class="form-control" required></InputNumber>
+            </div>
 
-    @if (errorMessage != null)
-    {
-        <p class="text-danger mt-2">@errorMessage</p>
-    }
-</EditForm>
-</div>
-</div>
+            <div class="d-flex align-items-center gap-2 mt-3">
+            <button type="submit" class="btn btn-primary" disabled="@isLoading">
+                @(isLoading ? "Saving..." : (eventModel.Id == 0 ? "Create Event" : "Update Event"))
+            </button>
+
+            @if (EventId.HasValue && EventId.Value > 0)
+            {
+                @if (!showConfirmDelete)
+                {
+                    <button class="btn btn-danger" @onclick="() => showConfirmDelete = true">
+                        Delete Event
+                    </button>
+                }
+                else
+                {
+                        <div class="d-flex align-items-center gap-2">
+                        <p>Are you sure you want to delete this event?</p>
+                        <button class="btn btn-danger" @onclick="DeleteEvent" disabled="@isLoading">
+                            @(isLoading ? "Deleting..." : "Yes, Delete")
+                        </button>
+                        <button class="btn btn-secondary ms-2" @onclick="() => showConfirmDelete = false">Cancel</button>
+                    </div>
+                }
+            }
+            </div>
 
 
-    @code {
-private EventRequest eventModel = new(); 
-private bool isLoading = false;
-private string? errorMessage;
+            @if (errorMessage != null)
+            {
+                <p class="text-danger mt-2">@errorMessage</p>
+            }
+        </EditForm>
+        </div>
+        </div>
 
+
+@code {
+    private EventRequest eventModel = new(); 
+    private bool isLoading = false;
+    private string? errorMessage;
     private string startTimeString = DateTime.Now.ToString("yyyy-MM-ddTHH:mm");
     private string endTimeString = DateTime.Now.AddHours(2).ToString("yyyy-MM-ddTHH:mm");
 
-private async Task SubmitEvent()
-{
-    isLoading = true;
-    errorMessage = null;
+    [Parameter] public int? EventId { get; set; } 
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (EventId.HasValue && EventId.Value > 0)
+        {
+            await LoadEvent(EventId.Value);
+         
+        }
+    }
+
+    private async Task LoadEvent(int id)
+    {
+        try
+        {
+            var response = await Http.GetFromJsonAsync<EventRequest>($"https://localhost:7206/events/{id}");
+            if (response != null)
+            {
+                eventModel = response;
+                startTimeString = eventModel.Start.ToString("yyyy-MM-ddTHH:mm");
+                endTimeString = eventModel.End.ToString("yyyy-MM-ddTHH:mm");
+            }
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Error loading event: {ex.Message}";
+        }
+    }
+
+    private async Task SubmitEvent()
+    {
+        isLoading = true;
+        errorMessage = null;
 
         try
         {
-            
             eventModel.Start = DateTime.Parse(startTimeString);
             eventModel.End = DateTime.Parse(endTimeString);
 
-            var response = await Http.PostAsJsonAsync("https://localhost:7206/events", eventModel);
+            HttpResponseMessage response;
+            if (eventModel.Id == 0)
+            {
+              
+                response = await Http.PostAsJsonAsync("https://localhost:7206/events", eventModel);
+            }
+            else
+            {
+                
+                response = await Http.PutAsJsonAsync($"https://localhost:7206/events/{eventModel.Id}", eventModel);
+            }
 
             if (response.IsSuccessStatusCode)
             {
-                var createdEvent = await response.Content.ReadFromJsonAsync<EventResponse>();
                 Navigation.NavigateTo("/admin/home");
             }
             else
             {
-                errorMessage = "Failed to create event. Please try again.";
+                errorMessage = "Failed to save event.";
             }
         }
         catch (Exception ex)
@@ -105,18 +163,48 @@ private async Task SubmitEvent()
         }
     }
 
+    @code {
+        private bool showConfirmDelete = false; // Styr om bekräftelsen visas
+
+        private async Task DeleteEvent()
+        {
+            isLoading = true;
+            errorMessage = null;
+
+            try
+            {
+                var response = await Http.DeleteAsync($"https://localhost:7206/events/{EventId.Value}");
+
+                if (response.IsSuccessStatusCode)
+                {
+                    Navigation.NavigateTo("/admin/home");
+                }
+                else
+                {
+                    errorMessage = "Failed to delete event.";
+                }
+            }
+            catch (Exception ex)
+            {
+                errorMessage = $"An error occurred: {ex.Message}";
+            }
+            finally
+            {
+                isLoading = false;
+            }
+        }
+    }
+
+
+
     private class EventRequest
     {
+        public int Id { get; set; } 
         public string Name { get; set; } = "";
         public string Description { get; set; } = "";
         public EventType Type { get; set; } = EventType.Other;
         public DateTime Start { get; set; } = DateTime.Now;
         public DateTime End { get; set; } = DateTime.Now.AddHours(2);
         public int MaxAttendees { get; set; } = 100;
-    }
-
-    private class EventResponse
-    {
-        public int Id { get; set; }
     }
 }

--- a/BlazorTicketCode/Pages/HomeAdmin.razor
+++ b/BlazorTicketCode/Pages/HomeAdmin.razor
@@ -78,7 +78,8 @@
 
     private void EditEvent(int id)
     {
-        Navigation.NavigateTo($"/edit/event/{id}");
+        Navigation.NavigateTo($"/create/{id}");
+        
     }
 
     public class EventResponse

--- a/TicketToCode.Api/Endpoints/Event/Delete.cs
+++ b/TicketToCode.Api/Endpoints/Event/Delete.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace TicketToCode.Api.Endpoints;
+
+public class DeleteEvent : IEndpoint
+{
+    public static void MapEndpoint(IEndpointRouteBuilder app) => app
+        .MapDelete("/events/{id}", Handle)
+        .WithSummary("Delete an event");
+
+    private static async Task<IResult> Handle(int id, [FromServices] AppDbContext db)
+    {
+        var ev = await db.Events.FindAsync(id);
+        if (ev == null)
+        {
+            return TypedResults.NotFound(new { Message = "Event not found" });
+        }
+
+        db.Events.Remove(ev);
+        await db.SaveChangesAsync();
+        return TypedResults.Ok(new { Message = "Event deleted successfully" });
+    }
+}

--- a/TicketToCode.Api/Endpoints/Event/Update.cs
+++ b/TicketToCode.Api/Endpoints/Event/Update.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace TicketToCode.Api.Endpoints;
+
+public class UpdateEvent : IEndpoint
+{
+    // Mapping för uppdatering av event
+    public static void MapEndpoint(IEndpointRouteBuilder app) => app
+        .MapPut("/events/{id}", Handle)
+        .WithSummary("Update an existing event");
+
+    // Request-typ för att ta emot data
+    public record Request(
+        string Name,
+        string Description,
+        EventType Type,
+        DateTime Start,
+        DateTime End,
+        int MaxAttendees
+    );
+
+    // Response-typ
+    public record Response(int Id, string Message);
+
+    // Uppdateringslogik
+    private static async Task<IResult> Handle(int id, Request request, [FromServices] AppDbContext db)
+    {
+        // Leta upp eventet i databasen
+        var ev = await db.Events.FindAsync(id);
+        if (ev == null)
+        {
+            return TypedResults.NotFound(new { Message = "Event not found" });
+        }
+
+        // Uppdatera eventets fält
+        ev.Name = request.Name;
+        ev.Description = request.Description;
+        ev.Type = request.Type;
+        ev.StartTime = request.Start;
+        ev.EndTime = request.End;
+        ev.MaxAttendees = request.MaxAttendees;
+
+        // Spara ändringar
+        await db.SaveChangesAsync();
+
+        return TypedResults.Ok(new Response(ev.Id, "Event updated successfully"));
+    }
+}


### PR DESCRIPTION
 Added endpoints delete event and update event
Change the create event page so that admin can edit and delete aswelll.
Förklaraing på svenska för annars kommer det ta för lång tid för mig att skriva:

 HttpResponseMessage response;
 if (eventModel.Id == 0)
 {
   
     response = await Http.PostAsJsonAsync("https://localhost:7206/events", eventModel);
 }
 else
 {
     
     response = await Http.PutAsJsonAsync($"https://localhost:7206/events/{eventModel.Id}", eventModel);
 }



I API:et sätts id automatiskt av databasen när ett nytt event skapas. När vi skapar ett nytt event i Blazor, har objektet ingen ID ännu – därför sätter vi Id = 0 för att eventet är nytt.

Men om vi redigerar ett befintligt event, så har det redan ett id (exempelvis 1, 2 eller 3). Då vet vi att vi ska uppdatera eventet istället för att skapa ett nytt.

När vi trycker på Edit Event från admins homepage så kommer man till /create{id} och då laddas eventinformationen genom api och formuläret fylls i :

protected override async Task OnInitializedAsync()
{
    if (EventId.HasValue && EventId.Value > 0)
    {
        await LoadEvent(EventId.Value);
    }
}

private async Task LoadEvent(int id)
{
    var response = await Http.GetFromJsonAsync<EventRequest>($"https://localhost:7206/events/{id}");
    if (response != null)
    {
        eventModel = response;
        startTimeString = eventModel.Start.ToString("yyyy-MM-ddTHH:mm");
        endTimeString = eventModel.End.ToString("yyyy-MM-ddTHH:mm");
    }
}

Fråga om det är något annat ni undrar :)

![image](https://github.com/user-attachments/assets/08334d4e-2d2a-4e83-bdc4-f5748657ddd2)
