### PR TITLE
Replace cookie-based login with localStorage + authorization support

### DIFF
--- a/BlazorTicketCode/App.razor
+++ b/BlazorTicketCode/App.razor
@@ -1,12 +1,15 @@
-﻿<Router AppAssembly="@typeof(App).Assembly">
-    <Found Context="routeData">
-        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
-        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
-    </Found>
-    <NotFound>
-        <PageTitle>Not found</PageTitle>
-        <LayoutView Layout="@typeof(MainLayout)">
-            <p role="alert">Sorry, there's nothing at this address.</p>
-        </LayoutView>
-    </NotFound>
-</Router>
+﻿@using Microsoft.AspNetCore.Components.Authorization
+<CascadingAuthenticationState>
+    <Router AppAssembly="@typeof(App).Assembly">
+        <Found Context="routeData">
+            <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+            <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+        </Found>
+        <NotFound>
+            <PageTitle>Not found</PageTitle>
+            <LayoutView Layout="@typeof(MainLayout)">
+                <p role="alert">Sorry, there's nothing at this address.</p>
+            </LayoutView>
+        </NotFound>
+    </Router>
+</CascadingAuthenticationState>

--- a/BlazorTicketCode/AuthStateService.cs
+++ b/BlazorTicketCode/AuthStateService.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.JSInterop;
+using System.Threading.Tasks;
+
+public class AuthStateService
+{
+    private readonly IJSRuntime _js;
+
+    public AuthStateService(IJSRuntime js)
+    {
+        _js = js;
+    }
+
+    public async Task SetAuth(string username, string role)
+    {
+        await _js.InvokeVoidAsync("localStorage.setItem", "username", username);
+        await _js.InvokeVoidAsync("localStorage.setItem", "role", role);
+    }
+
+    public async Task<string> GetUsername() =>
+        await _js.InvokeAsync<string>("localStorage.getItem", "username");
+
+    public async Task<string> GetRole() =>
+        await _js.InvokeAsync<string>("localStorage.getItem", "role");
+
+    public async Task Logout()
+    {
+        await _js.InvokeVoidAsync("localStorage.removeItem", "username");
+        await _js.InvokeVoidAsync("localStorage.removeItem", "role");
+    }
+}

--- a/BlazorTicketCode/BlazorTicketCode.csproj
+++ b/BlazorTicketCode/BlazorTicketCode.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.2" PrivateAssets="all" />
     <ProjectReference Include="..\TicketToCode.Core\TicketToCode.Core.csproj" />

--- a/BlazorTicketCode/CustomAuthenticationStateProvider.cs
+++ b/BlazorTicketCode/CustomAuthenticationStateProvider.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.AspNetCore.Components.Authorization;
+using System.Security.Claims;
+
+public class CustomAuthenticationStateProvider : AuthenticationStateProvider
+{
+    private readonly AuthStateService _authState;
+
+    public CustomAuthenticationStateProvider(AuthStateService authState)
+    {
+        _authState = authState;
+    }
+
+    public override async Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        var username = await _authState.GetUsername();
+        var role = await _authState.GetRole();
+
+        if (string.IsNullOrEmpty(username))
+        {
+            // Inte inloggad
+            var anonymous = new ClaimsPrincipal(new ClaimsIdentity());
+            return new AuthenticationState(anonymous);
+        }
+
+        // Skapa claims
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.Name, username),
+            new Claim(ClaimTypes.Role, role)
+        }, "FakeAuthType");
+
+        var user = new ClaimsPrincipal(identity);
+        return new AuthenticationState(user);
+    }
+
+    public void NotifyAuthenticationChanged()
+    {
+        NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
+    }
+}

--- a/BlazorTicketCode/Pages/Login.razor
+++ b/BlazorTicketCode/Pages/Login.razor
@@ -2,6 +2,7 @@
 @page "/login"
 @using TicketToCode.Core.Models
 @inject HttpClient Http
+@inject AuthStateService Auth
 @inject NavigationManager Navigation
 
 <div class="container mt-5">
@@ -50,38 +51,33 @@
 
     private async Task LoginUser()
     {
-        try
+        var result = await Http.PostAsJsonAsync("auth/login", new
         {
-            var request = new { Username = user.Username, Password = user.PasswordHash };
-            var response = await Http.PostAsJsonAsync("auth/login", request);
+            username = user.Username,
+            password = user.PasswordHash
+        });
+        if (result.IsSuccessStatusCode)
+        {
+            var loginResponse = await result.Content.ReadFromJsonAsync<LoginResponse>();
+            await Auth.SetAuth(loginResponse.Username, loginResponse.Role);
 
-            if (response.IsSuccessStatusCode)
+            if (loginResponse != null)
             {
-                var loginResponse = await response.Content.ReadFromJsonAsync<LoginResponse>();
 
-                if (loginResponse != null)
+
+                if (loginResponse.Role.Trim().ToLower() == "admin")
                 {
-                    
-
-                    if (loginResponse.Role.Trim().ToLower() == "admin") 
-                    {
-                        Navigation.NavigateTo("/admin/home");
-                    }
-                    else
-                    {
-                        Navigation.NavigateTo("/events");
-                    }
+                    Navigation.NavigateTo("/admin/home");
+                }
+                else
+                {
+                    Navigation.NavigateTo("/events");
                 }
             }
-
-            else
-            {
-                errorMessage = "Felaktigt användarnamn eller lösenord.";
-            }
         }
-        catch (Exception ex)
+        else
         {
-            errorMessage = "Ett fel uppstod vid inloggning.";
+            errorMessage = "Felaktigt användarnamn eller lösenord.";
         }
     }
 

--- a/BlazorTicketCode/Pages/Login.razor
+++ b/BlazorTicketCode/Pages/Login.razor
@@ -1,8 +1,8 @@
-﻿
-@page "/login"
+﻿@page "/login"
 @using TicketToCode.Core.Models
 @inject HttpClient Http
 @inject AuthStateService Auth
+@inject AuthenticationStateProvider AuthProvider
 @inject NavigationManager Navigation
 
 <div class="container mt-5">
@@ -60,11 +60,13 @@
         {
             var loginResponse = await result.Content.ReadFromJsonAsync<LoginResponse>();
             await Auth.SetAuth(loginResponse.Username, loginResponse.Role);
-
+            if (AuthProvider is CustomAuthenticationStateProvider customAuth)
+            {
+                customAuth.NotifyAuthenticationChanged();
+            }
             if (loginResponse != null)
             {
-
-
+                
                 if (loginResponse.Role.Trim().ToLower() == "admin")
                 {
                     Navigation.NavigateTo("/admin/home");

--- a/BlazorTicketCode/Program.cs
+++ b/BlazorTicketCode/Program.cs
@@ -7,6 +7,7 @@ builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("https://localhost:7206/") });
+builder.Services.AddScoped<AuthStateService>();
 builder.Services.AddScoped<BookingState>();
 
 await builder.Build().RunAsync();

--- a/BlazorTicketCode/Program.cs
+++ b/BlazorTicketCode/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using BlazorTicketCode;
+using Microsoft.AspNetCore.Components.Authorization;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
@@ -9,5 +10,7 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("https://localhost:7206/") });
 builder.Services.AddScoped<AuthStateService>();
 builder.Services.AddScoped<BookingState>();
+builder.Services.AddScoped<AuthenticationStateProvider, CustomAuthenticationStateProvider>();
+builder.Services.AddAuthorizationCore();
 
 await builder.Build().RunAsync();

--- a/BlazorTicketCode/_Imports.razor
+++ b/BlazorTicketCode/_Imports.razor
@@ -8,3 +8,4 @@
 @using Microsoft.JSInterop
 @using BlazorTicketCode
 @using BlazorTicketCode.Layout
+@using Microsoft.AspNetCore.Components.Authorization

--- a/TicketToCode.Api/Endpoints/Auth/Login.cs
+++ b/TicketToCode.Api/Endpoints/Auth/Login.cs
@@ -31,12 +31,6 @@ public class Login : IEndpoint
         {
             return TypedResults.BadRequest("Invalid username or password");
         }
-        context.Response.Cookies.Append("auth", $"{user.Username}:{user.Role}", new CookieOptions
-        {
-            HttpOnly = true,
-            SameSite = SameSiteMode.Strict,
-            Expires = DateTimeOffset.UtcNow.AddDays(7)
-        });
         var response = new Response(user.Username, user.Role);
         return TypedResults.Ok(response);
     }

--- a/TicketToCode.Api/Program.cs
+++ b/TicketToCode.Api/Program.cs
@@ -30,17 +30,6 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<EventService>();
 
-// Add cookie authentication
-builder.Services.AddAuthentication("Cookies")
-    .AddCookie("Cookies", options =>
-    {
-        options.Cookie.Name = "auth";
-        options.Cookie.HttpOnly = true;
-        options.Cookie.SameSite = SameSiteMode.Strict;
-    });
-
-builder.Services.AddAuthorization();
-
 var app = builder.Build();
 
 
@@ -59,8 +48,6 @@ if (app.Environment.IsDevelopment())
 }
 app.UseCors("AllowBlazorClient");
 app.UseHttpsRedirection();
-app.UseAuthentication();
-app.UseAuthorization();
 
 // Map all endpoints
 app.MapEndpoints<Program>();


### PR DESCRIPTION
After spending hours trying to get cookies to work across two different localhost ports and rebasing my branch twice, I decided to explore other options.

Cookies wouldn’t sync reliably, so I replaced the login cookie solution with localStorage.

I also implemented CustomAuthenticationStateProvider to integrate with Microsoft.AspNetCore.Components.Authorization, enabling us to use [Authorize] and <AuthorizeView> to control access based on roles.

✅ Username and role are now saved on login
✅ Admin pages can now be hidden from users, and vice versa
![image](https://github.com/user-attachments/assets/91c46f38-b885-4860-a2b5-8a7ebafcc5f5)
